### PR TITLE
Check for error conditions when reading files

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -50,8 +50,13 @@ int attach_file(Buffer *buffer, char *filename)
 	fseek(fp, 0L, SEEK_SET);
 	resize_gap(buffer->text, file_size);
 
-	while ((nread = fread(buf, 1, sizeof buf, fp)) > 0)
+	while ((nread = fread(buf, 1, sizeof buf, fp)) > 0 && !ferror(fp))
 		add_string(buffer->text, buf, nread);
+
+	if (ferror(fp)) {
+		fclose(fp);
+		return -1;
+	}
 
 	ret = fclose(fp);
 	if (ret) return -1;


### PR DESCRIPTION
While fread will return a short item count on error, it could be the case that fread returns 0 on an error. In such case, fclose is not obligated to return an error status. This would result in attach_file indicating that the read was successful, even though an error occurred during reading.
